### PR TITLE
api/account/update/email endpoint edge case fix

### DIFF
--- a/Backend/PooPosting.Application/Mappers/AccountMapper.cs
+++ b/Backend/PooPosting.Application/Mappers/AccountMapper.cs
@@ -23,7 +23,7 @@ public static class AccountMapper
 
     /// <summary>
     /// Maps an Account entity to AccountDto. Assumes Pictures, Likes, and Comments are already loaded.
-    /// Prefer ProjectToDto for IQueryable for more efficient data retrieval.
+    /// Prefer ProjectToDto over MapToDto IQueryable for more efficient data retrieval.
     /// </summary>
     public static AccountDto MapToDto(this Account a)
     {

--- a/Backend/PooPosting.Application/Mappers/AccountMapper.cs
+++ b/Backend/PooPosting.Application/Mappers/AccountMapper.cs
@@ -21,6 +21,10 @@ public static class AccountMapper
         });
 
 
+    /// <summary>
+    /// Maps an Account entity to AccountDto. Assumes Pictures, Likes, and Comments are already loaded.
+    /// Prefer ProjectToDto for IQueryable for more efficient data retrieval.
+    /// </summary>
     public static AccountDto MapToDto(this Account a)
     {
         return new AccountDto


### PR DESCRIPTION
fixed api/account/update/email edge case which was throwing when subject account had no nav props loaded.

Solution: Using ProjectToDto that directly fetches the data needed to display to the user instead of using MapToDto on object without navigation properties loaded.